### PR TITLE
Add Serena shared memories

### DIFF
--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,8 @@
+# Conventions
+
+- Repository governance artifacts are English even when chat is German.
+- Keep code comments, log/error text, identifiers, governance, GitHub text, and generated repo artifacts in English unless explicitly requested otherwise.
+- Preserve user edits; never revert or overwrite without explicit request.
+- Governance changes must preserve imported rule intent and structure unless owner approves consolidation or removal.
+- VS Code extension behavior spans package contributions, TextMate grammar, snippets, theme generation, formatter logic, and tests; validate the affected path rather than assuming app-only behavior.
+- Formatter fixtures in `src/test/suite/testfiles/` are expected outputs; update only with intentional formatter behavior changes.

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,10 @@
+# Core
+
+- Project: VS Code extension `intouch-language` for InTouch / Wonderware / AVEVA VBI language support.
+- Main extension entry: `src/extension.ts`; compiled output under `out/`; bundled extension output under `dist/extension.js`.
+- Language assets: `syntaxes/intouch.tmLanguage.json`, `language-configuration.json`, `snippets/vbi.json`, `themes/dark.json`.
+- Formatter/domain code: `src/formats.ts`, `src/formatCore.ts`, `src/functions.ts`, `src/nestingdef.ts`, `src/const.ts`.
+- Tests: `src/test/suite/*.test.ts` with fixtures in `src/test/suite/testfiles/`.
+- Project/package metadata and VS Code contribution manifest live in `package.json`; version source of truth is `package.json`.
+- Repository governance entrypoint: `AGENTS.md` delegates to `.github/AGENTS.md` plus `.github/agents/*.agent.md`.
+- Related memories: `mem:tech_stack`, `mem:suggested_commands`, `mem:conventions`, `mem:task_completion`.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,11 @@
+# Suggested Commands
+
+- Inspect state: `git status --short --branch`, `git branch -vv -a`, `git remote -v`.
+- File search on Windows/PowerShell: prefer `rg --files --hidden -g '!node_modules/**' -g '!.git/**'` and `rg --hidden -n '<pattern>' .` for governance/policy searches.
+- Compile: `npm run compile`.
+- Lint: `npm run lint`.
+- Test: `npm test`; on Linux CI with display requirements use `xvfb-run -a npm test`.
+- Bundle extension: `npm run bundle`.
+- Full prepublish build path: `npm run vscode:prepublish`.
+- Package extension: `npm run makePackage`.
+- Regenerate formatter fixtures: `npm run update:fixtures` only when fixture changes are intended.

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,7 @@
+# Task Completion
+
+- After `.ts`, `.tsx`, `.js`, extension manifest/package metadata, grammar, snippet, theme, or test changes, run the narrowest relevant available npm validation.
+- Default validation order from repo governance: `npm run lint` when present, `npm run compile` / typecheck equivalent when present, `npm test` when relevant, `npm run bundle` or `npm run vscode:prepublish` for packaging/build-surface changes.
+- Governance-only changes require governance consistency review: reread affected governance files and check agent routing, branch/workflow rules, tool policy, validation rules, version rules, and reporting rules for contradictions.
+- Before final reporting after file changes, inspect `git status --short --branch` and focused diffs/stat.
+- Serena memories can be checked from the repo root with `serena memories check`.

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,9 @@
+# Tech Stack
+
+- TypeScript VS Code extension; extension manifest and contributions are in `package.json`.
+- VS Code engine target currently `^1.104.0`.
+- Build path: TypeScript compile to `out/`, theme generation via `src/index.js`, esbuild bundle to `dist/extension.js`.
+- Test stack: Mocha plus `@vscode/test-electron`; Linux CI uses `xvfb-run -a npm test`.
+- Lint stack: ESLint 9 with TypeScript ESLint packages; script is `npm run lint`.
+- Package manager: npm; `package-lock.json` present and should stay aligned with `package.json`.
+- Extension packaging/publishing uses `vsce` scripts (`makePackage`, `publish*`) when dependencies provide the tool.


### PR DESCRIPTION
## Summary
- add audited Serena shared memory files for stable project context
- keep entries limited to shared project conventions, commands, stack, and completion guidance

## Safety audit
- read all five memory files fully
- checked for secrets, credentials, local paths, stale source-project terms, and temporary agent state
- no unsafe content found

## Validation
- git diff --check
- rg --hidden -n 'secret|token|password|credential|C:\\|/Users/|/home/|excel-loadlist|Excel|Office|Add-in|workbook|Workbook' .serena/memories/conventions.md .serena/memories/core.md .serena/memories/suggested_commands.md .serena/memories/task_completion.md .serena/memories/tech_stack.md

## Documentation impact
- No user-facing documentation update required; this PR adds Serena project memory metadata only.